### PR TITLE
Update redmine after version number change

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -53,4 +53,13 @@ class redmine::install {
     creates => "${redmine::install_dir}/Gemfile.lock",
     require => [ Package['bundler'], Package['make'], Package['gcc'] ],
   }
+
+  exec { 'bundle_update':
+    cwd         => $redmine::install_dir,
+    command     => 'bundle update',
+    refreshonly => true,
+    subscribe   => Vcsrepo['redmine_source'],
+    notify      => Exec['rails_migrations'],
+    require     => Exec['bundle_redmine'],
+  }
 }


### PR DESCRIPTION
When the repository updates, the user most likely wants to upgrade their redmine version. In this case we need to run bundle update and rake db:migrate. This should only occur on vcsrepo updates and only after we have successfully executed bundle install.
