### PR TITLE
Extended features

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -1,32 +1,41 @@
 # Class redmine::download
 class redmine::download {
 
-  # Install redmine from source
-
-  Exec {
-    cwd  => '/usr/src',
-    path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin/' ]
-  }
-
-  if $redmine::provider != 'wget' {
-    vcsrepo { 'redmine_source':
-      revision => $redmine::version,
-      source   => $redmine::download_url,
-      provider => $redmine::provider,
-      path     => $redmine::install_dir
+  case $redmine::provider {
+    'wget':   {
+      # Install redmine from source
+      ensure_packages([ 'tar', 'wget' ])
+      Exec {
+        cwd  => '/usr/src',
+        path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin/' ]
+      }
+      exec { 'redmine_source':
+        command => "wget -O redmine.tar.gz ${redmine::download_url}",
+        creates => '/usr/src/redmine.tar.gz',
+        require => Package['wget'],
+      } ->
+      exec { 'extract_redmine':
+        command => "mkdir -p ${redmine::install_dir} && tar xvzf redmine.tar.gz --strip-components=1 -C ${redmine::install_dir}",
+        creates => $redmine::install_dir,
+        require => Package['tar'],
+      }
     }
-  }
-  else {
-    ensure_packages([ 'tar', 'wget' ])
-    exec { 'redmine_source':
-      command => "wget -O redmine.tar.gz ${redmine::download_url}",
-      creates => '/usr/src/redmine.tar.gz',
-      require => Package['wget'],
-    } ->
-    exec { 'extract_redmine':
-      command => "mkdir -p ${redmine::install_dir} && tar xvzf redmine.tar.gz --strip-components=1 -C ${redmine::install_dir}",
-      creates => $redmine::install_dir,
-      require => Package['tar'],
+    'package': {
+      # Install redmine from package
+      package { 'redmine':
+        ensure => $redmine::version,
+        name => $redmine::package_name,
+        notify => Exec['rails_migrations'],
+      }
+    }
+    default: {
+      # Install redmine from scm
+      vcsrepo { 'redmine_source':
+        revision => $redmine::version,
+        source   => $redmine::download_url,
+        provider => $redmine::provider,
+        path     => $redmine::install_dir
+      }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,7 @@
 class redmine (
   $version              = '2.2.3',
   $download_url         = 'https://github.com/redmine/redmine',
+  $package_name         = 'redmine',
   $database_server      = 'localhost',
   $database_user        = 'redmine',
   $database_password    = 'redmine',
@@ -126,11 +127,18 @@ class redmine (
   $smtp_authentication  = false,
   $smtp_username        = '',
   $smtp_password        = '',
+  $configure_apache     = true,
+  $notify               = [Class['apache::service']],
+  $user                 = 'redmine',
+  $group                = 'redmine',
   $vhost_aliases        = 'redmine',
   $vhost_servername     = 'redmine',
   $webroot              = '/var/www/html/redmine',
   $install_dir          = '/usr/src/redmine',
   $provider             = 'git',
+  $install_ruby_dev     = true,
+  $enable_bundler       = true,
+  $bundle_exec          = false,
   $override_options     = {},
 ) {
   class { 'redmine::download': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,11 +5,24 @@ class redmine::install {
   # Install dependencies
 
   $generic_packages = [ 'make', 'gcc' ]
-  $debian_packages  = [ 'libmysql++-dev', 'libmysqlclient-dev', 'libmagickcore-dev', 'libmagickwand-dev', 'ruby-dev', 'libpq-dev', 'imagemagick' ]
-  $default_packages = ['postgresql-devel', 'sqlite-devel', 'ImageMagick-devel', 'ruby-devel', 'mysql-devel' ]
+  $debian_packages  = [ 'libmysql++-dev', 'libmysqlclient-dev', 'libmagickcore-dev', 'libmagickwand-dev', 'libpq-dev', 'imagemagick' ]
+  if $redmine::install_ruby_dev {
+    $ruby_dev_debian = ['ruby-dev']
+  } else {
+    $ruby_dev_debian = []
+  }
+  $default_packages = ['postgresql-devel', 'sqlite-devel', 'ImageMagick-devel', 'mysql-devel' ]
+  if $redmine::install_ruby_dev {
+    $ruby_dev_default = ['ruby-devel']
+  } else {
+    $ruby_dev_default = []
+  }
 
   case $::osfamily {
-    'Debian':   { $packages = concat($generic_packages, $debian_packages) }
+    'Debian':   {
+      $packages = concat($generic_packages, $debian_packages)
+      $ruby_dev = $ruby_dev_debian
+    }
     'RedHat':   {
       case $::operatingsystem {
         'Fedora': {
@@ -30,13 +43,23 @@ class redmine::install {
           $provider = 'mysql-devel'
         }
       }
-      $redhat_packages = ['postgresql-devel', 'sqlite-devel', 'ImageMagick-devel', 'ruby-devel', $provider ]
+      $redhat_packages = ['postgresql-devel', 'sqlite-devel', 'ImageMagick-devel', $provider ]
+      if $redmine::install_ruby_dev {
+        $ruby_dev_redhat = ['ruby-devel']
+      } else {
+        $ruby_dev_redhat = []
+      }
       $packages = concat($generic_packages, $redhat_packages)
+      $ruby_dev = $ruby_dev_redhat
     }
-    default:    { $packages = concat($generic_packages, $default_packages) }
+    default:    {
+      $packages = concat($generic_packages, $default_packages)
+      $ruby_dev = $ruby_dev_default
+    }
   }
 
   ensure_packages($packages)
+  ensure_packages($ruby_dev)
 
   case $redmine::database_adapter {
     'postgresql' : {
@@ -52,23 +75,25 @@ class redmine::install {
     path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin/' ]
   }
 
-  package { 'bundler':
-    ensure   => present,
-    provider => gem
-  } ->
+  if $redmine::enable_bundler {
+    package { 'bundler':
+      ensure   => present,
+      provider => gem
+    } ->
 
-  exec { 'bundle_redmine':
-    command => "bundle install --gemfile ${redmine::install_dir}/Gemfile --without ${without_gems}",
-    creates => "${redmine::install_dir}/Gemfile.lock",
-    require => [ Package['bundler'], Package['make'], Package['gcc'], Package[$packages] ],
-  }
+    exec { 'bundle_redmine':
+      command => "bundle install --gemfile ${redmine::install_dir}/Gemfile --without ${without_gems}",
+      creates => "${redmine::install_dir}/Gemfile.lock",
+      require => [ Package['bundler'], Package['make'], Package['gcc'], Package[$packages] ],
+    }
 
-  exec { 'bundle_update':
-    cwd         => $redmine::install_dir,
-    command     => 'bundle update',
-    refreshonly => true,
-    subscribe   => Vcsrepo['redmine_source'],
-    notify      => Exec['rails_migrations'],
-    require     => Exec['bundle_redmine'],
+    exec { 'bundle_update':
+      cwd         => $redmine::install_dir,
+      command     => '/usr/local/bin/bundle update',
+      refreshonly => true,
+      subscribe   => Vcsrepo['redmine_source'],
+      notify      => Exec['rails_migrations'],
+      require     => Exec['bundle_redmine'],
+    }
   }
 }


### PR DESCRIPTION
Added a new features, coming from need of slightly different deployment
* apache is now optional by configure_apache - we are using nginx/unicorn so forcing apache is counterproductive
* added package_name, as provider now supports also package option to install from package (we build our own package by Jenkins)
* added notify, optional parameter to enable refresh of external service when changes performed in redmine module (to notify unicorn for example)
* added user and group parameters, to sync all chowns for optional new user used by external service
* added install_ruby_dev, as ruby-dev package should not be owned by redmine module but ruby module itself (ex ploperations/ruby)
* added enable_bundler, to optionally turn off bundle install/update in case bundle is already supported by external package/repository
* added bundle exec, to optionaly prepend bundle exec to rake tasks, in case where vendor directory used by external package/repository
* refactored to to use rake generate_secret_token instead of obsoleted generated_session_store
All changes should be non-conflicting to existing functionality, tested vcsrepo method too and didnt found any major issues. I understand its lot of changes, but we may discuss and optimalize towards better overall functionality of module - its important to keep it as flexible for broadest audition.
