### PR TITLE
Feature/os params

### DIFF
--- a/manifests/database_mysql.pp
+++ b/manifests/database_mysql.pp
@@ -1,3 +1,4 @@
+# Class redmine::database_mysql
 class redmine::database_mysql {
 
     Mysql_database {

--- a/manifests/database_psql.pp
+++ b/manifests/database_psql.pp
@@ -1,3 +1,4 @@
+# Class redmine::database_psql
 class redmine::database_psql {
 
     postgresql::server::db { [$redmine::production_database,$redmine::development_database]:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,6 +133,7 @@ class redmine (
   $provider             = 'git',
   $override_options     = {},
 ) {
+  class { 'redmine::params': } ->
   class { 'redmine::download': } ->
   class { 'redmine::config': } ->
   class { 'redmine::install': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,39 +1,16 @@
 # Class redmine::install
 class redmine::install {
 
-
   # Install dependencies
 
   $generic_packages = [ 'make', 'gcc' ]
   $debian_packages  = [ 'libmysql++-dev', 'libmysqlclient-dev', 'libmagickcore-dev', 'libmagickwand-dev', 'ruby-dev', 'libpq-dev', 'imagemagick' ]
-  $default_packages = ['postgresql-devel', 'sqlite-devel', 'ImageMagick-devel', 'ruby-devel', 'mysql-devel' ]
+  $redhat_packages  = [ 'postgresql-devel', 'sqlite-devel', 'ImageMagick-devel', 'ruby-devel', $::redmine::params::mysql_devel ]
 
   case $::osfamily {
     'Debian':   { $packages = concat($generic_packages, $debian_packages) }
-    'RedHat':   {
-      case $::operatingsystem {
-        'Fedora': {
-          if is_integer($::operatingsystemrelease) and $::operatingsystemrelease >= 19 or $::operatingsystemrelease == 'Rawhide' {
-              $provider = 'mariadb-devel'
-            } else {
-              $provider = 'mysql-devel'
-            }
-        }
-        /^(RedHat|CentOS|Scientific)$/: {
-          if $::operatingsystemmajrelease >= 7 {
-              $provider = 'mariadb-devel'
-            } else {
-              $provider = 'mysql-devel'
-            }
-        }
-        default: {
-          $provider = 'mysql-devel'
-        }
-      }
-      $redhat_packages = ['postgresql-devel', 'sqlite-devel', 'ImageMagick-devel', 'ruby-devel', $provider ]
-      $packages = concat($generic_packages, $redhat_packages)
-    }
-    default:    { $packages = concat($generic_packages, $default_packages) }
+    'RedHat':   { $packages = concat($generic_packages, $redhat_packages) }
+    default:    { $packages = concat($generic_packages, $redhat_packages) }
   }
 
   ensure_packages($packages)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,28 @@
+# Class redmine::params
+class redmine::params {
+
+  case $::osfamily {
+    'RedHat': {
+      case $::operatingsystem {
+        'Fedora': {
+          if is_integer($::operatingsystemrelease) and $::operatingsystemrelease >= 19 or $::operatingsystemrelease == 'Rawhide' {
+            $mysql_devel = 'mariadb-devel'
+          } else {
+            $mysql_devel = 'mysql-devel'
+          }
+        }
+        /^(RedHat|CentOS|Scientific)$/: {
+          if $::operatingsystemmajrelease >= 7 {
+            $mysql_devel = 'mariadb-devel'
+          } else {
+            $mysql_devel = 'mysql-devel'
+          }
+        }
+        default: {
+          $mysql_devel = 'mysql-devel'
+        }
+      }
+    }
+  }
+
+}

--- a/spec/classes/redmine/redmine_spec.rb
+++ b/spec/classes/redmine/redmine_spec.rb
@@ -6,7 +6,7 @@ describe 'redmine', :type => :class do
     {
       :osfamily                   => 'Redhat',
       :operatingsystemrelease     => '6',
-      :operatingsystemmajrrelease => '6',
+      :operatingsystemmajrelease  => '6',
       :domain                     => 'test.com',
       :concat_basedir             => '/dne'
     }
@@ -227,7 +227,7 @@ describe 'redmine', :type => :class do
       {
         :osfamily                   => 'Debian',
         :operatingsystemrelease     => '6',
-        :operatingsystemmajrrelease => '6',
+        :operatingsystemmajrelease  => '6',
         :concat_basedir             => '/dne'
       }
     end
@@ -244,8 +244,8 @@ describe 'redmine', :type => :class do
       {
         :osfamily => 'RedHat',
         :operatingsystemrelease => '6',
-        :operatingsystemmajrrelease => '6',
         :concat_basedir => '/dne'
+        :operatingsystemmajrelease  => '6',
       }
     end
 

--- a/spec/classes/redmine/redmine_spec.rb
+++ b/spec/classes/redmine/redmine_spec.rb
@@ -242,10 +242,10 @@ describe 'redmine', :type => :class do
   context 'redhat' do
     let :facts do
       {
-        :osfamily => 'RedHat',
-        :operatingsystemrelease => '6',
-        :concat_basedir => '/dne'
+        :osfamily                   => 'RedHat',
+        :operatingsystemrelease     => '6',
         :operatingsystemmajrelease  => '6',
+        :concat_basedir             => '/dne'
       }
     end
 

--- a/spec/classes/redmine/redmine_spec.rb
+++ b/spec/classes/redmine/redmine_spec.rb
@@ -255,4 +255,19 @@ describe 'redmine', :type => :class do
     it { should contain_package('ImageMagick-devel')}
   end
 
+  context 'redhat7' do
+    let :facts do
+      {
+        :osfamily                   => 'RedHat',
+        :operatingsystem            => 'RedHat',
+        :operatingsystemrelease     => '7',
+        :operatingsystemmajrelease  => '7',
+        :concat_basedir             => '/dne'
+      }
+    end
+
+    it { should contain_package('mariadb-devel') }
+  end
+
+
 end

--- a/tests/params.pp
+++ b/tests/params.pp
@@ -1,0 +1,1 @@
+class { 'redmine::params': }


### PR DESCRIPTION
Add tests for mariadb-devel packages on RedHat 7.

Refactor case statement for deciding mysql-devel package name into redmine::params class, and simplify logic in install.pp