### PR TITLE
Plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ plugin can be installed like this:
 Plugins can be installed via git (the default) or any other version control system.
 
 Bundle updates and database migrations will be handled automatically. You can update your plugin by
-setting `ensure => latest` or directly specifying the version. More comles updates can be done by subscribing
+setting `ensure => latest` or directly specifying the version. More complex updates can be done by subscribing
 to the plugin resource (via `subscribe => Redmine::Plugin['yourplugin']`)
 
 Uninstalling plugins can be done by simply setting `ensure => absent`. Again, database migration and

--- a/README.md
+++ b/README.md
@@ -56,9 +56,29 @@ Install default redmine with a postgresql database
     }
 ```
 
+Installing Plugins
+------------------
 
-Parameters
-----------
+Plugins can be installed and configured via the redmine::plugin resource. For example, a simple
+plugin can be installed like this:
+
+```puppet
+    redmine::plugin { 'redmine_plugin'
+      source => 'git://example.com/redmine_plugin.git'
+    }
+```
+Plugins can be installed via git (the default) or any other version control system.
+
+Bundle updates and database migrations will be handled automatically. You can update your plugin by
+setting `ensure => latest` or directly specifying the version. More comles updates can be done by subscribing
+to the plugin resource (via `subscribe => Redmine::Plugin['yourplugin']`)
+
+Uninstalling plugins can be done by simply setting `ensure => absent`. Again, database migration and
+deletion are done for you.
+
+
+Redmine Parameters
+------------------
 
 #####`version`
 
@@ -172,3 +192,19 @@ default:
 #####`plugins`
 
   Optional hash of plugins to install, which are passed to redmine::plugin
+
+Plugin Parameters
+------------------
+
+#####`ensure`
+  Wether the plugin should be installed.
+  Possible values are installed, latest, and absent.
+
+#####`source`
+  Repository of the plugin. Required
+
+#####`version`
+  Set to desired version.
+
+#####`provider`
+  The vcs provider. Default: git

--- a/README.md
+++ b/README.md
@@ -172,3 +172,7 @@ default:
   foo: bar
 ```
   Currently does not support nested options.
+
+#####`plugins`
+
+  Optional hash of plugins to install, which are passed to redmine::plugin

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,16 +36,14 @@ class redmine::config {
     ensure  => 'directory',
   }
 
-  file { "${redmine::webroot}/config/database.yml":
+  file { "${redmine::install_dir}/config/database.yml":
     ensure  => present,
-    content => template('redmine/database.yml.erb'),
-    require => File[$redmine::webroot]
+    content => template('redmine/database.yml.erb')
   }
 
-  file { "${redmine::webroot}/config/configuration.yml":
+  file { "${redmine::install_dir}/config/configuration.yml":
     ensure  => present,
-    content => template('redmine/configuration.yml.erb'),
-    require => File[$redmine::webroot]
+    content => template('redmine/configuration.yml.erb')
   }
 
   apache::vhost { 'redmine':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,6 +111,9 @@
 # [*override_options*]
 #   Extra options to add to configuration.yml. Empty by default. Expects a hash.
 #
+# [*plugins*]
+#   Optional hash of plugins, which are passed to redmine::plugin
+#
 class redmine (
   $version              = '2.2.3',
   $download_url         = 'https://github.com/redmine/redmine',
@@ -132,6 +135,7 @@ class redmine (
   $install_dir          = '/usr/src/redmine',
   $provider             = 'git',
   $override_options     = {},
+  $plugins              = {},
 ) {
   class { 'redmine::params': } ->
   class { 'redmine::download': } ->
@@ -139,5 +143,4 @@ class redmine (
   class { 'redmine::install': } ->
   class { 'redmine::database': } ->
   class { 'redmine::rake': }
-
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,7 +46,6 @@ class redmine::install {
     command     => 'bundle update',
     refreshonly => true,
     subscribe   => Vcsrepo['redmine_source'],
-    notify      => Exec['rails_migrations'],
     require     => Exec['bundle_redmine'],
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,6 +41,8 @@ class redmine::install {
     notify  => Exec['rails_migrations'],
   }
 
+  create_resources('redmine::plugin', $redmine::plugins)
+
   exec { 'bundle_update':
     cwd         => $redmine::install_dir,
     command     => 'bundle update',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,6 +46,7 @@ class redmine::install {
     command     => 'bundle update',
     refreshonly => true,
     subscribe   => Vcsrepo['redmine_source'],
+    notify      => Exec['rails_migrations'],
     require     => Exec['bundle_redmine'],
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,0 +1,70 @@
+define redmine::plugin (
+  $source   = undef,
+  $version  = undef,
+  $provider = 'git',
+  $ensure   = present,
+  $migrate  = false,
+  $bundle   = false,
+) {
+
+  $install_dir = "${redmine::install_dir}/plugins/${name}"
+  if $ensure == purged or $ensure == absent {
+
+    if $migrate {
+      exec { "rake redmine:plugins:migrate NAME=${name} VERSION=0":
+        notify      => Class['apache::service'],
+        path        => ['/bin','/usr/bin', '/usr/local/bin'],
+        environment => ['HOME=/root','RAILS_ENV=production','REDMINE_LANG=en'],
+        provider    => 'shell',
+        cwd         => $redmine::webroot,
+        before      => File[$install_dir],
+        onlyif      => "test -d ${install_dir}",
+      }
+    }
+    file { $install_dir:
+      ensure  => $ensure,
+      force   => true,
+      require => Class['redmine'],
+    }
+
+  } else {
+
+    if $source == undef {
+      fail("no source specified for redmine plugin '${name}'")
+    }
+    validate_string($source)
+
+    case $provider {
+      'svn' : {
+        $provider_package = 'subversion'
+      }
+      'hg': {
+        $provider_package = 'mercurial'
+      }
+      default: {
+        $provider_package = $provider
+      }
+    }
+    ensure_packages($provider_package)
+
+    if $migrate and $bundle {
+      $notify = [Exec['bundle_update'], Exec['plugin_migrations']]
+    } elsif $migrate {
+      $notify = Exec['plugin_migrations']
+    } elsif $bundle {
+      $notify = Exec['bundle_update']
+    } else {
+      $notify = undef
+    }
+
+    vcsrepo { $install_dir:
+      ensure   => $ensure,
+      revision => $version,
+      source   => $source,
+      provider => $provider,
+      notify   => $notify,
+      require  => [ Package[$provider_package]
+                  , Class['redmine'] ]
+    }
+  }
+}

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -28,7 +28,7 @@ define redmine::plugin (
       path        => ['/bin','/usr/bin', '/usr/local/bin'],
       environment => ['HOME=/root','RAILS_ENV=production','REDMINE_LANG=en'],
       provider    => 'shell',
-      cwd         => $redmine::webroot,
+      cwd         => $redmine::install_dir,
       before      => Vcsrepo[$install_dir],
       require     => Exec['bundle_update'],
       onlyif      => "test -d ${install_dir}",

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -30,8 +30,12 @@ define redmine::plugin (
       provider    => 'shell',
       cwd         => $redmine::webroot,
       before      => Vcsrepo[$install_dir],
+      require     => Exec['bundle_update'],
       onlyif      => "test -d ${install_dir}",
     }
+    $notify = undef
+  } else {
+    $notify = Exec['bundle_update']
   }
 
   if $source == undef {
@@ -57,7 +61,7 @@ define redmine::plugin (
     revision => $version,
     source   => $source,
     provider => $provider,
-    notify   => Exec['bundle_update'],
+    notify   => $notify,
     require  => [ Package[$provider_package]
                 , Class['redmine'] ]
   }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -3,7 +3,7 @@
 #
 #[*ensure*]
 #  Wether the plugin should be installed.
-#  Possible values are installed and absent.
+#  Possible values are installed, latest, and absent.
 #
 #[*source*]
 #  Repository of the plugin. Required

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -63,6 +63,6 @@ define redmine::plugin (
     provider => $provider,
     notify   => $notify,
     require  => [ Package[$provider_package]
-                , Class['redmine'] ]
+                , Exec['bundle_redmine'] ]
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,14 +1,40 @@
+#= Type redmine::plugin
+#== Parameters
+#
+#[*ensure*]
+#  Wether the plugin should be installed.
+#  Possible values are installed and absent.
+#
+#[*source*]
+#  Repository of the plugin. Required
+#
+#[*version*]
+#  Set to desired version.
+#
+#[*provider*]
+#  The vcs provider. Default: git
+#
+#[*migrate*]
+#  Boolean indicating if plugin migrations should be done.
+#  See the installation instruction of the plugin if this is the case.
+#  Default: false
+#
+#[*bundle*]
+#  Boolean indicating if the plugin requires that new gems are to be installed via bundle.
+#  See the installation instruction of the plugin if this is the case.
+#  Default: false
+#
 define redmine::plugin (
+  $ensure   = present,
   $source   = undef,
   $version  = undef,
   $provider = 'git',
-  $ensure   = present,
   $migrate  = false,
   $bundle   = false,
 ) {
 
   $install_dir = "${redmine::install_dir}/plugins/${name}"
-  if $ensure == purged or $ensure == absent {
+  if $ensure == absent {
 
     if $migrate {
       exec { "rake redmine:plugins:migrate NAME=${name} VERSION=0":

--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -17,6 +17,13 @@ class redmine::rake {
   # Perform rails migrations
   exec { 'rails_migrations':
     command     => 'rake db:migrate',
+    notify      => Exec['plugin_migrations'],
+    refreshonly => true,
+  }
+
+  # Perform plugin migrations
+  exec { 'plugin_migrations':
+    command     => 'rake redmine:plugins:migrate',
     notify      => Class['apache::service'],
     refreshonly => true,
   }

--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -17,7 +17,9 @@ class redmine::rake {
   # Perform rails migrations
   exec { 'rails_migrations':
     command     => 'rake db:migrate',
+    subscribe   => Vcsrepo['redmine_source'],
     notify      => Exec['plugin_migrations'],
+    require     => Exec['bundle_update'],
     refreshonly => true,
   }
 
@@ -25,6 +27,7 @@ class redmine::rake {
   exec { 'plugin_migrations':
     command     => 'rake redmine:plugins:migrate',
     notify      => Class['apache::service'],
+    require     => Exec['bundle_update'],
     refreshonly => true,
   }
 

--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -17,9 +17,7 @@ class redmine::rake {
   # Perform rails migrations
   exec { 'rails_migrations':
     command     => 'rake db:migrate',
-    subscribe   => Vcsrepo['redmine_source'],
     notify      => Exec['plugin_migrations'],
-    require     => Exec['bundle_update'],
     refreshonly => true,
   }
 
@@ -27,7 +25,6 @@ class redmine::rake {
   exec { 'plugin_migrations':
     command     => 'rake redmine:plugins:migrate',
     notify      => Class['apache::service'],
-    require     => Exec['bundle_update'],
     refreshonly => true,
   }
 

--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -5,13 +5,13 @@ class redmine::rake {
     path        => ['/bin','/usr/bin', '/usr/local/bin'],
     environment => ['HOME=/root','RAILS_ENV=production','REDMINE_LANG=en'],
     provider    => 'shell',
-    cwd         => $redmine::webroot,
+    cwd         => $redmine::install_dir,
   }
 
   # Create session store
   exec { 'session_store':
     command => 'rake generate_session_store && touch .session_store',
-    creates => "${redmine::webroot}/.session_store",
+    creates => "${redmine::install_dir}/.session_store",
   }
 
   # Perform rails migrations
@@ -31,7 +31,7 @@ class redmine::rake {
   # Seed DB data
   exec { 'seed_db':
     command => 'rake redmine:load_default_data && touch .seed',
-    creates => "${redmine::webroot}/.seed",
+    creates => "${redmine::install_dir}/.seed",
     notify  => Class['apache::service'],
     require => Exec['rails_migrations'],
   }

--- a/spec/classes/redmine/redmine_spec.rb
+++ b/spec/classes/redmine/redmine_spec.rb
@@ -19,16 +19,16 @@ describe 'redmine', :type => :class do
     it { should create_class('redmine::database') }
     it { should create_class('redmine::rake') }
 
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/adapter: mysql/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/database: redmine/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/database: redmine_development/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/host: localhost/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/username: redmine/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/password: redmine/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/adapter: mysql/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/database: redmine/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/database: redmine_development/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/host: localhost/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/username: redmine/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/password: redmine/) }
 
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/address: localhost/) }
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/domain: test.com/) }
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/port: 25/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/address: localhost/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/domain: test.com/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/port: 25/) }
 
     it { should contain_package('make') }
     it { should contain_package('gcc') }
@@ -117,7 +117,7 @@ describe 'redmine', :type => :class do
         }
       end
 
-      it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/adapter: mysql2\n/) }
+      it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/adapter: mysql2\n/) }
     end
     context 'ruby1.9' do
       let :facts do
@@ -131,7 +131,7 @@ describe 'redmine', :type => :class do
         }
       end
 
-      it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/adapter: mysql2\n/) }
+      it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/adapter: mysql2\n/) }
     end
     context 'ruby1.8' do
       let :facts do
@@ -145,7 +145,7 @@ describe 'redmine', :type => :class do
         }
       end
 
-      it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/adapter: mysql\n/) }
+      it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/adapter: mysql\n/) }
     end
   end
 
@@ -161,12 +161,12 @@ describe 'redmine', :type => :class do
       }
     end
 
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/adapter: mysql2/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/database: redproddb/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/database: reddevdb/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/host: db1/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/username: dbuser/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/password: password/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/adapter: mysql2/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/database: redproddb/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/database: reddevdb/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/host: db1/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/username: dbuser/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/password: password/) }
 
     it { should_not contain_mysql_database }
     it { should_not contain_mysql_user }
@@ -186,12 +186,12 @@ describe 'redmine', :type => :class do
       }
     end
 
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/adapter: postgresql/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/database: redproddb/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/database: reddevdb/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/host: localhost/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/username: dbuser/) }
-    it { should contain_file('/var/www/html/redmine/config/database.yml').with_content(/password: password/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/adapter: postgresql/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/database: redproddb/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/database: reddevdb/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/host: localhost/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/username: dbuser/) }
+    it { should contain_file('/usr/src/redmine/config/database.yml').with_content(/password: password/) }
 
     it { should_not contain_mysql_database }
     it { should_not contain_mysql_user }
@@ -214,8 +214,8 @@ describe 'redmine', :type => :class do
       }
     end
 
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/foo: bar/) }
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/additional: options/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/foo: bar/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/additional: options/) }
 
   end
 
@@ -258,12 +258,12 @@ describe 'redmine', :type => :class do
       }
     end
 
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/address: smtp/) }
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/domain: google.com/) }
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/port: 1234/) }
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/authentication: :login/) }
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/user_name: user/) }
-    it { should contain_file('/var/www/html/redmine/config/configuration.yml').with_content(/password: password/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/address: smtp/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/domain: google.com/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/port: 1234/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/authentication: :login/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/user_name: user/) }
+    it { should contain_file('/usr/src/redmine/config/configuration.yml').with_content(/password: password/) }
   end
 
   context 'set webroot' do
@@ -274,8 +274,7 @@ describe 'redmine', :type => :class do
     end
 
     it { should contain_file('/opt/redmine').with({'ensure' => 'link'}) }
-    it { should contain_file('/opt/redmine/config/configuration.yml') }
-    it { should contain_file('/opt/redmine/config/configuration.yml') }
+    it { should contain_apache__vhost('redmine').with({'docroot' => '/opt/redmine/public'}) }
   end
 
   context 'debian' do

--- a/spec/defines/redmine_plugin_spec.rb
+++ b/spec/defines/redmine_plugin_spec.rb
@@ -51,7 +51,7 @@ describe 'redmine::plugin', :type => :define do
     it { should contain_exec('rake redmine:plugins:migrate NAME=test_plugin VERSION=0').with(
       'cwd'    => '/opt/redmine',
       'before' => 'Vcsrepo[/opt/redmine/plugins/test_plugin]',
-      'onlyif' => 'test -d /opt/redmine/plugins/test_plugin',
+      'onlyif' => 'test -d /opt/redmine/plugins/test_plugin'
     ) }
 
     it { should contain_vcsrepo('/opt/redmine/plugins/test_plugin').with(

--- a/spec/defines/redmine_plugin_spec.rb
+++ b/spec/defines/redmine_plugin_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe 'redmine::plugin', :type => :define do
+
+  let :facts do
+    {
+      :osfamily                   => 'Redhat',
+      :operatingsystemrelease     => '6',
+      :operatingsystemmajrelease  => '6',
+      :domain                     => 'test.com',
+      :concat_basedir             => '/dne'
+    }
+  end
+
+  let :pre_condition do
+    'class { "redmine": install_dir => "/opt/redmine" }'
+  end
+
+  let(:title) { 'test_plugin'  }
+
+  context 'no parameters' do
+    it 'should raise an error when the source is not present' do
+      expect { subject  }.to raise_error(Puppet::Error, /source/)
+    end
+  end
+
+  context 'plugin install' do
+    let :params do
+      {
+        :source  => 'git://example.git',
+        :version => '1.2.3'
+      }
+    end
+
+    it { should contain_vcsrepo('/opt/redmine/plugins/test_plugin').with(
+      'revision' => '1.2.3',
+      'provider' => 'git',
+      'source'   => 'git://example.git',
+      'notify'   => 'Exec[bundle_update]'
+    ) }
+  end
+
+  context 'plugin uninstall' do
+    let :params do
+      {
+        :ensure => 'absent',
+        :source => 'git://example.git'
+      }
+    end
+
+    it { should contain_exec('rake redmine:plugins:migrate NAME=test_plugin VERSION=0').with(
+      'cwd'    => '/opt/redmine',
+      'before' => 'Vcsrepo[/opt/redmine/plugins/test_plugin]',
+      'onlyif' => 'test -d /opt/redmine/plugins/test_plugin',
+    ) }
+
+    it { should contain_vcsrepo('/opt/redmine/plugins/test_plugin').with(
+      'ensure' => 'absent'
+    ) }
+  end
+
+  context 'provider svn' do
+    let :params do
+      {
+        :source   => 'git://example.git',
+        :provider => 'svn'
+      }
+    end
+
+    it {should contain_package('subversion')}
+    it { should contain_vcsrepo('/opt/redmine/plugins/test_plugin').that_requires('Package[subversion]') }
+  end
+end

--- a/spec/defines/redmine_plugin_spec.rb
+++ b/spec/defines/redmine_plugin_spec.rb
@@ -20,7 +20,7 @@ describe 'redmine::plugin', :type => :define do
 
   context 'no parameters' do
     it 'should raise an error when the source is not present' do
-      expect { subject  }.to raise_error(Puppet::Error, /source/)
+      expect { should compile }.to raise_error(/source/)
     end
   end
 


### PR DESCRIPTION
Adds support for plugins. Documentation in README and tests will follow. Supports all the basic functionality to manage most plugins. Some plugins require extra work like updating or moving resources. This can easily be done by the user by creating their own Exec, making it refreshonly and having it be notified by the plugin resource.