### PR TITLE
avoid Evaluation Error in Puppet 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class redmine::params {
           }
         }
         /^(RedHat|CentOS|Scientific)$/: {
-          if $::operatingsystemmajrelease >= 7 {
+          if $::operatingsystemmajrelease >= '7' {
             $mysql_devel = 'mariadb-devel'
           } else {
             $mysql_devel = 'mysql-devel'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,14 +5,14 @@ class redmine::params {
     'RedHat': {
       case $::operatingsystem {
         'Fedora': {
-          if is_integer($::operatingsystemrelease) and $::operatingsystemrelease >= 19 or $::operatingsystemrelease == 'Rawhide' {
+          if is_integer($::operatingsystemrelease) and versioncmp($::operatingsystemrelease, '18') == 1 or $::operatingsystemrelease == 'Rawhide' {
             $mysql_devel = 'mariadb-devel'
           } else {
             $mysql_devel = 'mysql-devel'
           }
         }
         /^(RedHat|CentOS|Scientific)$/: {
-          if $::operatingsystemmajrelease >= '7' {
+          if versioncmp($::operatingsystemmajrelease, '6') == 1 {
             $mysql_devel = 'mariadb-devel'
           } else {
             $mysql_devel = 'mysql-devel'


### PR DESCRIPTION
$::operatingsystemmajrelease is a string and Puppet 4 gives an error when comparing it to an int.
```
# Error: Evaluation Error: Comparison of: String >= Integer, is not possible. Caused by 'A String is not comparable to a non String'. at /etc/puppetlabs/agent/code/modules/redmine/manifests/params.pp:15:43 on node redmine.domain
```