### PR TITLE
Set default webroot to apache docroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Parameters
 
 #####`webroot`
 
-  Directory in which redmine web files will be installed. Default: '/var/www/html/redmine'
+  Directory in which redmine web files will be installed. Default: 'DOCROOT/redmine'
+  DOCROOT is the document root of your apache server, usually /var/www or /var/www/html
 
 #####`install_dir`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,7 +96,9 @@
 #
 # [*webroot*]
 #   Directory in which redmine web files will be installed.
-#   Default: '/var/www/html/redmine'
+#   Default: 'DOCROOT/redmine'
+#   where DOCROOT is the document root of your apache server,
+#   usually /var/www or /var/www/html
 #
 # [*install_dir*]
 #   Path where redmine will be installed
@@ -128,7 +130,7 @@ class redmine (
   $smtp_password        = '',
   $vhost_aliases        = 'redmine',
   $vhost_servername     = 'redmine',
-  $webroot              = '/var/www/html/redmine',
+  $webroot              = "${apache::docroot}/redmine",
   $install_dir          = '/usr/src/redmine',
   $provider             = 'git',
   $override_options     = {},

--- a/spec/classes/redmine/redmine_spec.rb
+++ b/spec/classes/redmine/redmine_spec.rb
@@ -12,6 +12,10 @@ describe 'redmine', :type => :class do
     }
   end
 
+  let :pre_condition do
+    'class { "apache": }'
+  end
+
   context 'no parameters' do
     it { should create_class('redmine::config') }
     it { should create_class('redmine::download') }
@@ -292,6 +296,7 @@ describe 'redmine', :type => :class do
     it { should contain_package('libmysqlclient-dev') }
     it { should contain_package('libmagickcore-dev') }
     it { should contain_package('libmagickwand-dev') }
+    it { should contain_class('redmine').with('webroot' => '/var/www/redmine') }
 
   end
 


### PR DESCRIPTION
The default webroot /var/www/html/redmine can only be created if the
parent directory exists. This is not the case for debian based systems
where the default docroot is /var/www and not /var/www/html. Taken the
docroot directly from apache ensures that the directory exists.