### PR TITLE
Feature/test kitchen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 pkg/*
-Gemfile.lock
+*.lock
 spec/fixtures
 *.swp
 Vagrantfile
 .vagrant
+.tmp/
+modules/
+.bundle/
+.librarian/
+.kitchen/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,21 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: puppet_apply
+  manifests_path: manifests
+  modules_path: modules
+  hiera_data_path: hiera
+
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-12.04
+  - name: ubuntu-10.04
+  - name: centos-6.6
+  - name: debian-7.7
+
+suites:
+  - name: default
+    provisioner:
+      manifest: test_site.pp

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,6 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
   - name: ubuntu-12.04
-  - name: ubuntu-10.04
   - name: centos-6.6
   - name: debian-7.7
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ gem "puppet-lint", "1.1.0"
 gem "rspec-puppet", "2.0.0"
 gem "puppetlabs_spec_helper", "0.8.2"
 gem "puppet-syntax", "1.4.1"
+gem 'test-kitchen'
+gem 'librarian-puppet'
+gem 'kitchen-puppet'
+gem 'kitchen-vagrant'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,10 @@ gem "puppet-lint", "1.1.0"
 gem "rspec-puppet", "2.0.0"
 gem "puppetlabs_spec_helper", "0.8.2"
 gem "puppet-syntax", "1.4.1"
-gem 'test-kitchen'
-gem 'librarian-puppet'
-gem 'kitchen-puppet'
-gem 'kitchen-vagrant'
+
+if RUBY_VERSION >= '1.9'
+  gem 'test-kitchen'
+  gem 'librarian-puppet'
+  gem 'kitchen-puppet'
+  gem 'kitchen-vagrant'
+end

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+#^syntax detection
+
+forge "https://forgeapi.puppetlabs.com"
+
+# use dependencies defined in metadata.json
+metadata
+
+# use dependencies defined in Modulefile
+# modulefile
+
+# A module from the Puppet Forge
+mod 'stahnma-epel'
+
+# A module from git
+# mod 'puppetlabs-ntp',
+#   :git => 'git://github.com/puppetlabs/puppetlabs-ntp.git'
+
+# A module from a git branch/tag
+# mod 'puppetlabs-apt',
+#   :git => 'https://github.com/puppetlabs/puppetlabs-apt.git',
+#   :ref => '1.4.x'
+
+# A module from Github pre-packaged tarball
+# mod 'puppetlabs-apache', '0.6.0', :github_tarball => 'puppetlabs/puppetlabs-apache'

--- a/README.md
+++ b/README.md
@@ -209,3 +209,8 @@ Plugin Parameters
 
 #####`provider`
   The vcs provider. Default: git
+
+Contributing
+------------
+
+See the wiki for further information about contributing to this module: https://github.com/johanek/johanek-redmine/wiki

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,9 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: /var/lib/hiera
+:hierarchy:
+  - "%{::osfamily}-%{::operatingsystemrelease}"
+  - "%{::operatingsystem}-%{::operatingsystemrelease}"
+  - common

--- a/hiera/Ubuntu-10.04.yaml
+++ b/hiera/Ubuntu-10.04.yaml
@@ -1,2 +1,0 @@
----
-redmine::version: 2.2.3

--- a/hiera/Ubuntu-10.04.yaml
+++ b/hiera/Ubuntu-10.04.yaml
@@ -1,0 +1,2 @@
+---
+redmine::version: 2.2.3

--- a/hiera/Ubuntu-12.04.yaml
+++ b/hiera/Ubuntu-12.04.yaml
@@ -1,0 +1,2 @@
+---
+redmine::version: 2.2.3

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -1,0 +1,3 @@
+---
+redmine::version: 2.6.2
+redmine::vhost_servername: localhost

--- a/manifests/test_site.pp
+++ b/manifests/test_site.pp
@@ -3,3 +3,4 @@ class { 'apache': }
 class { 'apache::mod::passenger': }
 class { '::mysql::server': }
 class { 'redmine': }
+ensure_packages(['wget'])

--- a/manifests/test_site.pp
+++ b/manifests/test_site.pp
@@ -1,0 +1,5 @@
+class { 'epel': }->
+class { 'apache': }
+class { 'apache::mod::passenger': }
+class { '::mysql::server': }
+class { 'redmine': }

--- a/test/integration/default/serverspec/redmine_spec.rb
+++ b/test/integration/default/serverspec/redmine_spec.rb
@@ -1,0 +1,30 @@
+require 'serverspec'
+
+set :backend, :exec
+
+if os[:family] == 'redhat'
+  apacheservice = 'httpd'
+elsif ['debian', 'ubuntu'].include?(os[:family])
+  apacheservice = 'apache2'
+end
+
+describe service(apacheservice) do
+  it { should be_running }
+end
+
+describe port(80) do
+  it { should be_listening }
+end
+
+describe service('mysqld') do
+  it { should be_running }
+end
+
+describe command('wget http://localhost') do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('passenger-status') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /redmine/ }
+end

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,6 +1,0 @@
-class { 'vcsrepo': }
-class { 'apache': }
-class { 'passenger': }
-class { 'mysql': }
-class { 'mysql::server': }
-class { 'redmine': }

--- a/tests/params.pp
+++ b/tests/params.pp
@@ -1,1 +1,0 @@
-class { 'redmine::params': }


### PR DESCRIPTION
This PR adds support for running integration tests via test-kitchen. This means you can automatically build a VM for each supported distribution and release, apply the module and run integration tests to validate that the module actually works as intended.

At the same time, I've created a wiki on github and provided information about the module's tests and how to run them - this should provide some information about working with test-kitchen. This is linked from the README.md under the contributing section.

The intention is that anyone can run these tests on their local box to validate their changes, and a reviewer can do the same to make sure things are working before releasing a new version. There's no automated running of these tests at the moment, but that's something I'd like to investigate in the future.