### PR TITLE
Add note about requiring EPEL on RedHat platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Required modules:
 Optional modules:
 * puppetlabs-vcsrepo if you want to download redmine from a repository (the default)
 
+RedHat or CentOS:
+* EPEL yum repository needs to be configured
+
 Example Usage
 -------------
 


### PR DESCRIPTION
I decided against adding a puppet module to handle this, as it doesn't make sense on debian/Ubuntu (although safe) and would make the examples more confusing.

Fixes #48 