### PR TITLE
Fix to solve circular reference with Apache, when default_vhost => false.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 # Class redmine::config
 class redmine::config {
 
-  include 'apache'
+  require 'apache'
 
   File {
     owner => $apache::params::user,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 # Class redmine::config
 class redmine::config {
 
-  require 'apache'
+  include 'apache'
 
   File {
     owner => $apache::params::user,


### PR DESCRIPTION
Without this fix, this simple manifest creates circular error:

```
node 'redtest.adam-g551jm.statystyka.net' {
  class { 'apache':
    default_vhost => false,
  }

  class { 'apache::mod::passenger':
  }

  class { '::mysql::server': }

  class { 'redmine':
    version           => '3.0.0',
    database_password => "mypassword",
    vhost_aliases     => "redmin.adam-g551jm.statystyka.net",
    install_dir       => '/opt/redmine',
    webroot           => "${apache::docroot}/redmine"
  }
}

Error: Could not apply complete catalog: Found 1 dependency cycle:
(Exec[concat_/etc/apache2/ports.conf] => Concat[/etc/apache2/ports.conf] => Class[Apache] => Class[Redmine::Config] => Apache::Vhost[redmine] => Apache::Listen[80] => Concat::Fragment[Listen 80] => File[/var/lib/puppet/concat/_etc_apache2_ports.conf/fragments/10_Listen 80] => Exec[concat_/etc/apache2/ports.conf])
Try the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz
```
