### PR TITLE
Changes for 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ##2.3.0
-WARNING: With the next major version we will up the default redmine version.
+WARNING: With the next major version (3.0.0) we will up the default redmine version.
 Check if you can upgrade to 2.6.x or explicitly set your version.
 Now passenger starts redmine on apache start. This removes the delay the first
 visitor experiences after a restart of the webserver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+##2.3.0
+WARNING: With the next major version we will up the default redmine version.
+Check if you can upgrade to 2.6.x or explicitly set your version.
+Now passenger starts redmine on apache start. This removes the delay the first
+visitor experiences after a restart of the webserver.
+
+###Features
+- Start a passenger worker for redmine when apache starts
+
 ##2.2.0
 
 ###Notes

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -59,7 +59,10 @@ class redmine::config {
       servername      => $redmine::vhost_servername,
       serveraliases   => $redmine::vhost_aliases,
       options         => 'Indexes FollowSymlinks ExecCGI',
-      custom_fragment => 'RailsBaseURI /',
+      custom_fragment => "
+        RailsBaseURI /
+        PassengerPreStart http://${redmine::vhost_servername}
+        ",
     }
   }
 

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -11,7 +11,7 @@ class redmine::download {
   if $redmine::provider != 'wget' {
     ensure_packages($redmine::params::provider_package)
     vcsrepo { 'redmine_source':
-      revision => $redmine::version,
+      revision => $redmine::params::version,
       source   => $redmine::download_url,
       provider => $redmine::provider,
       path     => $redmine::install_dir,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@
 #   When using this option the vhost config is your responsibility.
 #
 class redmine (
-  $version              = '2.2.3',
+  $version              = undef,
   $download_url         = 'https://github.com/redmine/redmine',
   $database_server      = 'localhost',
   $database_user        = 'redmine',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,12 +24,21 @@ class redmine::params {
       }
     }
   }
+
   if $redmine::database_adapter {
     $real_adapter = $redmine::database_adapter
   } elsif versioncmp($::rubyversion, '1.9') >= 0 {
     $real_adapter = 'mysql2'
   } else {
     $real_adapter = 'mysql'
+  }
+
+  if $redmine::version {
+    $version = $redmine::version
+  } else {
+    $version = '2.2.3'
+    warning('The default version will change to 2.6.4 in the next major release')
+    warning('If this is not what you want, please specify a version in hiera or your manifest')
   }
 
   case $redmine::provider {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "johanek-redmine",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "Johan van den Dorpe",
   "license": "Apache-2.0",
   "summary": "Module to install redmine",


### PR DESCRIPTION
If we want to change the default version, we should bring up a warning as soon as possible. This version also adds a passenegr directive to start a worker for redmine on apache start.