### PR TITLE
Set owner and group to the configurable variables from apache

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,8 +4,8 @@ class redmine::config {
   require 'apache'
 
   File {
-    owner => $apache::params::user,
-    group => $apache::params::group,
+    owner => $apache::user,
+    group => $apache::group,
     mode  => '0644'
   }
 


### PR DESCRIPTION
Hello.

The variable $apache::params::user is not configurable, i'd rather see us using $apache::user instead.

Let me know what you think.
Thanks!